### PR TITLE
ci: dependabot Auto Merge

### DIFF
--- a/.github/workflows/github-auto-merge.yml
+++ b/.github/workflows/github-auto-merge.yml
@@ -1,0 +1,15 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
參考資料：
https://github.com/marketplace/actions/dependabot-auto-merge

設定 `minor` 以下版本自動合併
設定只有是機器人的時候才執行
`if: github.actor == 'dependabot[bot]'`
